### PR TITLE
Allow sub-classing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ within your Doctrine entities.
 
 ⚠️ **Jan 2022: Doctrine ORM 2.11 finally introduced [native support](https://www.doctrine-project.org/2022/01/11/orm-2.11.html) for PHP 8.1 enums! 🎉** 
 
-**This means that this bundle will soon or later be discontinued. Please upgrade your dependencies!**
+**Still this package may be useful for defining custom enum types, in particular if one wants to use MySQL enums on the DB side (for whatever reason)**
+
+The `feature/allow-child-classes` branch removes the `final` keyword
+from the class and makes all member `protected` instead of `private`
+in order to make it possible to extend this class.
 
 ## Installation
 

--- a/src/Type/NativeEnum.php
+++ b/src/Type/NativeEnum.php
@@ -13,11 +13,11 @@ use ReflectionEnum;
 use function is_a;
 use function sprintf;
 
-final class NativeEnum extends Type
+class NativeEnum extends Type
 {
-    private string $name;
-    private string $class;
-    private BackedEnumType $type;
+    protected string $name;
+    protected string $class;
+    protected BackedEnumType $type;
 
     public static function registerEnumType(string $enumType, ?string $enumClass = null): void
     {

--- a/src/Type/NativeEnum.php
+++ b/src/Type/NativeEnum.php
@@ -26,11 +26,11 @@ class NativeEnum extends Type
             throw new InvalidArgumentException(sprintf('Class `%s` is not a valid enum.', $enumClass));
         }
 
-        self::addType($enumType, self::class);
-        $type = self::getType($enumType);
+        parent::addType($enumType, static::class);
+        $type = parent::getType($enumType);
         $type->name = $enumType;
         $type->class = $enumClass;
-        $type->type = self::detectEnumType($enumClass);
+        $type->type = static::detectEnumType($enumClass);
     }
 
     public function getSQLDeclaration(array $column, AbstractPlatform $platform): string


### PR DESCRIPTION
Not a bug-report, just for the record: this PR makes all members protected instead of private and removes the final keyword from the class etc. in order to allow sub-classing. This can be useful -- even though ORM -- now supports native PHP enums, in order to map the PHP enum to something else (e.g. a MySQL enum, knowning that MySQL enums are a questionable feature).

